### PR TITLE
Updated extract_domain function (corrected)

### DIFF
--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -34,6 +34,10 @@ extract_domain <- function(wt){
   stopifnot("input is not a wt_dt object" = is.wt_dt(wt))
   vars_exist(wt,vars = "url")
   wt[,domain:=urltools::domain(url)]
+  wt[,domain_name:=urltools::suffix_extract(host)$domain]
+  wt[,suffix:=urltools::suffix_extract(host)$suffix]
+  wt[,domain:=paste0(domain_name, '.', suffix)]
+  wt[,c("domain_name", "suffix"):=NULL]
   wt[]
 }
 

--- a/R/preprocess.R
+++ b/R/preprocess.R
@@ -33,7 +33,7 @@ add_duration <- function(wt, reset = 3600){
 extract_domain <- function(wt){
   stopifnot("input is not a wt_dt object" = is.wt_dt(wt))
   vars_exist(wt,vars = "url")
-  wt[,domain:=urltools::domain(url)]
+  wt[,host:=urltools::domain(url)]
   wt[,domain_name:=urltools::suffix_extract(host)$domain]
   wt[,suffix:=urltools::suffix_extract(host)$suffix]
   wt[,domain:=paste0(domain_name, '.', suffix)]


### PR DESCRIPTION
The previous version of this function just extracted the host (i.e., everything between the scheme e.g. https:// and the port or path e.g. /section/page123)
For example, from an URL like https://www.maps.google.com/something the previous version would extract www.maps.google.com, but most people think of google.com when they speak of the domain in that case. Of course for all the URLs in the test_data, this won't make a difference, but in the real world it will.

Feel free to adapt the code if not data.tabley enough