### PR TITLE
Putting timestamp in posixct format

### DIFF
--- a/R/wt_dt.R
+++ b/R/wt_dt.R
@@ -14,15 +14,17 @@ NULL
 
 #' @rdname wt_dt
 #' @param x [data.table] containing the correct set of variables (panelist_id,url and timestamp)
+#' @param timestamp_format string. Specify the raw timestamp's formatting. Defaults to "%Y-%m-%d %H:%M:%OS".
 #' @return a webtrack data object
 #' @examples
 #' data("test_data")
 #' wt <- as.wt_dt(test_data)
 #' is.wt_dt(wt)
 #' @export
-as.wt_dt <- function(x){
+as.wt_dt <- function(x, timestamp_format = "%Y-%m-%d %H:%M:%OS"){
   stopifnot(is.data.table(x))
   vars_exist(x,vars = c("panelist_id", "url", "timestamp"))
+  x <- x[,timestamp:=as.POSIXct(timestamp, format = timestamp_format)]
   data.table::setorder(x,panelist_id,timestamp)
   class(x) <- c("wt_dt",class(x))
   x

--- a/man/webtrackR-package.Rd
+++ b/man/webtrackR-package.Rd
@@ -6,9 +6,9 @@
 \alias{webtrackR-package}
 \title{webtrackR: Analysing Web Tracking Data and Online News Behaviour}
 \description{
-\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
 
-Implements data structures and methods to work with web tracking data. This includes data preprocessing steps, methods to construct audience networks as described in Mangold & Scharkow (2020) \doi{10.1080/19312458.2020.1724274}, and metrics of news audience polarization described in Mangold & Scharkow (2022) \doi{10.1080/19312458.2022.2085249}.
+Implements data structures and methods to work with web tracking data. This includes data preprocessing steps, methods to construct audience networks as described in Mangold & Scharkow (2020) <doi:10.1080/19312458.2020.1724274>, and metrics of news audience polarization described in Mangold & Scharkow (2022) <doi:10.1080/19312458.2022.2085249>.
 }
 \seealso{
 Useful links:

--- a/man/wt_dt.Rd
+++ b/man/wt_dt.Rd
@@ -6,12 +6,14 @@
 \alias{is.wt_dt}
 \title{An S3 class, based on \link{data.table}, to store webtrack data}
 \usage{
-as.wt_dt(x)
+as.wt_dt(x, timestamp_format = "\%Y-\%m-\%d \%H:\%M:\%OS")
 
 is.wt_dt(x)
 }
 \arguments{
 \item{x}{\link{data.table} containing the correct set of variables (panelist_id,url and timestamp)}
+
+\item{timestamp_format}{string. Specify the raw timestamp's formatting. Defaults to "\%Y-\%m-\%d \%H:\%M:\%OS".}
 }
 \value{
 a webtrack data object


### PR DESCRIPTION
To make sure that all timestamp-based computation work out fine, I think it is best to turn the timestamp into posixct format right from the start.